### PR TITLE
breaking changes in recipes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Suggests: knitr,
     rmarkdown,
     testthat
 VignetteBuilder: knitr
-Imports: recipes,
+Imports: recipes (>= 0.1.3.9002),
     dplyr,
     tibble,
     magrittr,
@@ -22,4 +22,6 @@ Imports: recipes,
     tidyselect,
     methods,
     generics
-RoxygenNote: 6.1.0
+Remotes:
+    tidymodels/recipes
+RoxygenNote: 6.1.0.9000

--- a/R/custom_filter.R
+++ b/R/custom_filter.R
@@ -222,15 +222,15 @@ prep.step_custom_filter <- function(x, training, info = NULL, ...) {
 # bake step (/apply step on new data).
 #' @export
 #' @importFrom tibble as_tibble
-bake.step_custom_filter <- function(object, newdata, ...) {
+bake.step_custom_filter <- function(object, new_data, ...) {
   
   # remove problematic variables.
   if (length(object$removals) > 0) {
-    newdata <- newdata[, !(colnames(newdata) %in% object$removals)]
+    new_data <- new_data[, !(colnames(new_data) %in% object$removals)]
   }
   
   # return data set after filtering.
-  as_tibble(newdata)
+  as_tibble(new_data)
   
 }
 
@@ -273,6 +273,7 @@ tidy.step_custom_filter <- function(x, ...) {
     }
   }
   
+  res$id <- x$id
   res
   
 }

--- a/R/custom_transformation.R
+++ b/R/custom_transformation.R
@@ -310,12 +310,12 @@ prep.step_custom_transformation <- function(x, training, info = NULL, ...) {
 #' @importFrom purrr invoke
 #' @importFrom recipes bake
 #' @importFrom tibble as_tibble
-bake.step_custom_transformation <- function(object, newdata, ...) {
+bake.step_custom_transformation <- function(object, new_data, ...) {
   
   #### prepare arguments before calling the bake helper function.
   
-  # add mandatory argument for 'x' - set to newdata.
-  args <- list(x = newdata)
+  # add mandatory argument for 'x' - set to new_data.
+  args <- list(x = new_data)
   
   # add intermediate output from the prep helper function.
   if (!is.null(object$prep_output)) {
@@ -349,12 +349,12 @@ bake.step_custom_transformation <- function(object, newdata, ...) {
     })
   
   # check dimensions of output from bake helper function.
-  if (nrow(bake_function_output) != nrow(newdata)) {
+  if (nrow(bake_function_output) != nrow(new_data)) {
     stop("There was a mismatch between the number of rows ",
          "in the output from the bake helper function (",
          nrow(bake_function_output),
          ") and the number of rows of the input data (",
-         nrow(newdata), ").")
+         nrow(new_data), ").")
   }
   
   # append to input data the output from the bake helper function.
@@ -364,7 +364,7 @@ bake.step_custom_transformation <- function(object, newdata, ...) {
                    "bind_cols" = {
                      
                      # bind output columns to input data.frame.
-                     newdata %>%
+                     new_data %>%
                        as_tibble() %>%
                        bind_cols(bake_function_output)
                      
@@ -373,7 +373,7 @@ bake.step_custom_transformation <- function(object, newdata, ...) {
                    # replace selected variables with output.
                    "replace" = {
                      
-                     newdata %>%
+                     new_data %>%
                        as_tibble() %>%
                        # drop selected vars.
                        select(-c(object$selected_vars)) %>%
@@ -409,5 +409,7 @@ print.step_custom_transformation <-
 tidy.step_custom_transformation <- function(x, ...) {
   
   res <- tibble(terms = sel2char(x$terms))
+  res$id <- x$id
+  res
   
 }


### PR DESCRIPTION
We'll be releasing a new version of `recipes` in the next week and there are a few breaking changes. See the [news file](https://tidymodels.github.io/recipes/dev/news/index.html) for details. We are trying to get the breaking changes out in one release; some are for upcoming features that aren't implemented yet and we didn't want to stagger them. 

The biggest changes are the differences in argument names in the new version, the most significant is `new_data` in stead of `newdata` in `prep`. 

The plan is to send `recipes` to CRAN next week (I hope) and send `caret` in once that is accepted. I will alert CRAN that other packages are affected and the maintainers have been notified. I'll update this thread once that process starts. 
